### PR TITLE
IOTPROT-986 handle re-send in block-wise transfer.

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/server/internal/BlockWiseIncomingTransaction.java
+++ b/coap-core/src/main/java/com/mbed/coap/server/internal/BlockWiseIncomingTransaction.java
@@ -55,17 +55,15 @@ class BlockWiseIncomingTransaction {
         BlockOption reqBlock = request.headers().getBlock1Req();
 
         int assumedCollectedPayloadSize = reqBlock.getNr() * reqBlock.getSize();
-        if (payload.size() > assumedCollectedPayloadSize) {
-            //size has changed
-            byte[] receivedBytes = payload.toByteArray();
-            payload.reset();
-            payload.write(receivedBytes, 0, assumedCollectedPayloadSize);
-        } else if (payload.size() < assumedCollectedPayloadSize) {
+        if (payload.size() < assumedCollectedPayloadSize) {
             throw new CoapRequestEntityIncomplete();
         }
 
         try {
-            payload.write(request.getPayload());
+            // Don't append in case of resends.
+            if (payload.size() == assumedCollectedPayloadSize) {
+                payload.write(request.getPayload());
+            }
         } catch (IOException e) {
             // should never happen
             throw new CoapCodeException(Code.C500_INTERNAL_SERVER_ERROR, e);

--- a/lwm2m/pom.xml
+++ b/lwm2m/pom.xml
@@ -43,7 +43,7 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <scope>test</scope>
-            <version>2.5</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
Handle re-send in block-wise transfer.
    
Old block-wise implementation didn't handle re-sends, therefore the block transaction would fail unnecessarily.

Bump commons.io from 2.5 to 2.7 due to vulnerability.
