### PR TITLE
Fix: socket closed problem

### DIFF
--- a/coap-core/src/main/java/com/mbed/coap/transport/udp/DatagramSocketTransport.java
+++ b/coap-core/src/main/java/com/mbed/coap/transport/udp/DatagramSocketTransport.java
@@ -89,7 +89,7 @@ public class DatagramSocketTransport extends BlockingCoapTransport {
         } catch (SocketTimeoutException ex) {
             return true;
         } catch (IOException ex) {
-            if (!ex.getMessage().startsWith("Socket closed")) {
+            if (!ex.getMessage().startsWith("Socket closed")&&!ex.getMessage().startsWith("socket closed")) {
                 LOGGER.warn(ex.getMessage(), ex);
             }
         } catch (Exception ex) {


### PR DESCRIPTION
case:
when server.stop() or client.stop(), the console would show "java.net.SocketException: socket closed"

review test case:
java-coap/coap-core/src/test/java/protocolTests/ClientServerTest.java